### PR TITLE
Test for Pub/Sub bug where unsubscribing hangs

### DIFF
--- a/tests/ServiceStack.Redis.Tests/RedisPubSubTests.cs
+++ b/tests/ServiceStack.Redis.Tests/RedisPubSubTests.cs
@@ -174,5 +174,39 @@ namespace ServiceStack.Redis.Tests
 			Assert.That(channelsSubscribed, Is.EqualTo(publishChannelCount));
 			Assert.That(channelsUnSubscribed, Is.EqualTo(publishChannelCount));
 		}
+		
+		[Test]
+        public void Can_Subscribe_and_UnSubscribe_without_messages()
+        {
+            const string channelName = "CHANNEL";
+
+            bool finishedSuccessfully = false;
+
+            using (var subscription = Redis.CreateSubscription())
+            {
+                ThreadPool.QueueUserWorkItem(o =>
+                {
+                    try
+                    {
+                        Log("Subscribing to channel in thread...");
+                        subscription.SubscribeToChannels(channelName);
+                        Log("No longer subscribed to channel in thread.");
+                        finishedSuccessfully = true;
+                    }
+                    catch
+                    {
+                        Log("Exception in thread");
+                    }
+                });
+
+                System.Threading.Thread.Sleep(1000);
+
+                Log("UnSubscribing from channel.");
+                subscription.UnSubscribeFromAllChannels();
+            }
+
+            Assert.That(finishedSuccessfully);
+            Log("Completed successfully.");
+        }		
 	}
 }


### PR DESCRIPTION
I think the root cause is that the Unsubscribe functions all send data to Redis and wait for the response message. But the Subscribe functions are already looping over the connection and steals the response first. So the Unsubscribe function hangs.

P.S. This is my first pull request ever! Please let me know if I screwed it up somehow :)
