### PR TITLE
Make connections timeout if ConnectTimeout is set.

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -66,6 +66,7 @@ namespace ServiceStack.Redis
 
         public string Host { get; private set; }
         public int Port { get; private set; }
+        public int ConnectTimeout { get; set; }
         public int RetryTimeout { get; set; }
         public int RetryCount { get; set; }
         public int SendTimeout { get; set; }

--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -30,7 +30,15 @@ namespace ServiceStack.Redis
 			};
 			try
 			{
-				socket.Connect(Host, Port);
+                if (ConnectTimeout == 0)
+                {
+                    socket.Connect(Host, Port);
+                }
+                else
+                {
+                    var connectResult = socket.BeginConnect(Host, Port, null, null);
+                    connectResult.AsyncWaitHandle.WaitOne(ConnectTimeout, true);
+                }
 
 				if (!socket.Connected)
 				{


### PR DESCRIPTION
The current Redis Client implementation hangs for up to 15 seconds if
asked to connect to a Redis server that is currently offline. This code
allows developers to override this behavior by explicitly setting a
connection timeout.

If ConnectTimeout is set to zero milliseconds (the default setting), RedisClient will still hang for up to 15 seconds if the server is unavailable.

If ConnectTimeout is set and the server cannot be contacted, an "Unable to
Connect" RedisException is raised.

This patch builds on a change I made to the ServiceStack/Redis.Interfaces project. I added the ConnectTimeout property in that project. That change must be
pulled first so that this code can compile.

I did not replace lib/ServiceStack.Interfaces.dll, as my build environment
is likely different than that of the project maintainers.
