### PR TITLE
A faster way to put clients back in the pool

### DIFF
--- a/src/ServiceStack.Redis/PooledRedisClientManager.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.cs
@@ -342,6 +342,32 @@ namespace ServiceStack.Redis
 			throw new NotSupportedException("Cannot add unknown client back to the pool");
 		}
 
+		/// <summary>
+		/// Disposes the read only client.
+		/// </summary>
+		/// <param name="client">The client.</param>
+		public void DisposeReadOnlyClient( RedisNativeClient client )
+		{
+			lock( readClients )
+			{
+				client.Active = false;
+				Monitor.PulseAll( readClients );
+			}
+		}
+
+		/// <summary>
+		/// Disposes the write client.
+		/// </summary>
+		/// <param name="client">The client.</param>
+		public void DisposeWriteClient( RedisNativeClient client )
+		{
+			lock( writeClients )
+			{
+				client.Active = false;
+				Monitor.PulseAll( writeClients );
+			}
+		}
+
 		public void Start()
 		{
 			if (writeClients.Length > 0 || readClients.Length > 0)


### PR DESCRIPTION
These are two specific methods for client disposal, they avoid having to needlessly loop over a every single clients in the pool. 
We've found that when you have a large number of read clients, we did not want to have to loop through all the read clients every time we want to put a write client back in the pool.

Another solution we considered was hashing each client Id to quickly know if it was a read or write client, and then just looking up the hash inside of DisposeClient method. But went with this one for simplicity sake, and it required less changes.
