### PR TITLE
Fixed Eval + new Redis command (BRPOPLPUSH) implemented

### DIFF
--- a/src/ServiceStack.Redis/Commands.cs
+++ b/src/ServiceStack.Redis/Commands.cs
@@ -87,6 +87,7 @@ namespace ServiceStack.Redis
 		public readonly static byte[] BLPop = "BLPOP".ToUtf8Bytes();
 		public readonly static byte[] BRPop = "BRPOP".ToUtf8Bytes();
 		public readonly static byte[] RPopLPush = "RPOPLPUSH".ToUtf8Bytes();
+        public readonly static byte[] BRPopLPush = "BRPOPLPUSH".ToUtf8Bytes();
 
 		public readonly static byte[] SAdd = "SADD".ToUtf8Bytes();
 		public readonly static byte[] SRem = "SREM".ToUtf8Bytes();

--- a/src/ServiceStack.Redis/Generic/RedisClientList.Generic.cs
+++ b/src/ServiceStack.Redis/Generic/RedisClientList.Generic.cs
@@ -237,5 +237,10 @@ namespace ServiceStack.Redis.Generic
 		{
 			return client.PopAndPushItemBetweenLists(this, toList);
 		}
+
+		public T BlockingPopAndPush(IRedisList<T> toList, TimeSpan? timeOut)
+		{
+			return client.BlockingPopAndPushItemBetweenLists(this, toList, timeOut);
+		}
 	}
 }

--- a/src/ServiceStack.Redis/Generic/RedisTypedClient_List.cs
+++ b/src/ServiceStack.Redis/Generic/RedisTypedClient_List.cs
@@ -187,5 +187,10 @@ namespace ServiceStack.Redis.Generic
 		{
 			return DeserializeValue(client.RPopLPush(fromList.Id, toList.Id));
 		}
+
+        public T BlockingPopAndPushItemBetweenLists(IRedisList<T> fromList, IRedisList<T> toList, TimeSpan? timeOut)
+		{
+            return DeserializeValue(client.BRPopLPush(fromList.Id, toList.Id, (int)timeOut.GetValueOrDefault().TotalSeconds));
+		}
 	}
 }

--- a/src/ServiceStack.Redis/RedisClient_List.cs
+++ b/src/ServiceStack.Redis/RedisClient_List.cs
@@ -196,5 +196,10 @@ namespace ServiceStack.Redis
 		{
 			return RPopLPush(fromListId, toListId).FromUtf8Bytes();
 		}
+
+		public string BlockingPopAndPushItemBetweenLists(string fromListId, string toListId, TimeSpan? timeOut)
+		{
+            return BRPopLPush(fromListId, toListId, (int)timeOut.GetValueOrDefault().TotalSeconds).FromUtf8Bytes();
+		}
 	}
 }

--- a/src/ServiceStack.Redis/RedisExtensions.cs
+++ b/src/ServiceStack.Redis/RedisExtensions.cs
@@ -122,5 +122,20 @@ namespace ServiceStack.Redis
     			byteArgs[i] = args[i].ToUtf8Bytes();
     		return byteArgs;
     	}
+
+        public static  byte[][] PrependByteArray(this byte[][] args, byte[] valueToPrepend)
+        {
+            var newArgs = new byte[args.Length + 1][];
+            newArgs[0] = valueToPrepend;
+            var i = 1;
+            foreach (var arg in args)
+                newArgs[i++] = arg;
+
+            return newArgs;
+        }
+        public static  byte[][] PrependInt(this byte[][] args, int valueToPrepend)
+        {
+            return args.PrependByteArray(valueToPrepend.ToUtf8Bytes());
+        }
     }
 }

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -1057,6 +1057,17 @@ namespace ServiceStack.Redis
             return SendExpectData(Commands.RPopLPush, fromListId.ToUtf8Bytes(), toListId.ToUtf8Bytes());
         }
 
+        public byte[] BRPopLPush(string fromListId, string toListId, int timeOutSecs)
+        {
+            if (fromListId == null)
+                throw new ArgumentNullException("fromListId");
+            if (toListId == null)
+                throw new ArgumentNullException("toListId");
+
+            byte[][] result= SendExpectMultiData(Commands.BRPopLPush, fromListId.ToUtf8Bytes(), toListId.ToUtf8Bytes(), timeOutSecs.ToUtf8Bytes());
+            return result.Length == 0 ? null : result[1];
+        }
+
         #endregion
 
 

--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -684,9 +684,9 @@ namespace ServiceStack.Redis
 		public int EvalInt(string body, int numberKeysInArgs, params byte[][] keys)
 		{
 			if (body == null)
-				throw new ArgumentNullException("body");
+				throw new ArgumentNullException("body");            
 
-			var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys);
+			var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys.PrependInt(numberKeysInArgs));
 
 			return SendExpectInt(cmdArgs);
 		}
@@ -696,7 +696,7 @@ namespace ServiceStack.Redis
 			if (body == null)
 				throw new ArgumentNullException("body");
 
-			var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys);
+		    var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys.PrependInt(numberKeysInArgs));
 			return SendExpectData(cmdArgs).FromUtf8Bytes();
 		}
 
@@ -705,7 +705,7 @@ namespace ServiceStack.Redis
 			if (body == null)
 				throw new ArgumentNullException("body");
 
-			var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys);
+            var cmdArgs = MergeCommandWithArgs(Commands.Eval, body.ToUtf8Bytes(), keys.PrependInt(numberKeysInArgs));
 
 			return SendExpectMultiData(cmdArgs);
 		}


### PR DESCRIPTION
Fixed Eval functions because they did not send the number of keys argument to Redis (v. 2.6)
Added support for BRPOPLPUSH
