### PR TITLE
Decreased memory fragmentation

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -228,8 +228,18 @@ namespace ServiceStack.Redis
 		{
 			if ((cmdBufferIndex + cmdBytes.Length) > cmdBuffer.Length)
 			{
+				int requiredLength = cmdBufferIndex + cmdBytes.Length;
+				const int lohThreshold = 85000 - 1;
 				const int breathingSpaceToReduceReallocations = (32 * 1024);
-				var newLargerBuffer = new byte[cmdBufferIndex + cmdBytes.Length + breathingSpaceToReduceReallocations];
+				int newSize = lohThreshold;
+				if (requiredLength <= lohThreshold) {
+					if (requiredLength + breathingSpaceToReduceReallocations <= lohThreshold) {
+						newSize = requiredLength + breathingSpaceToReduceReallocations;
+					}
+				} else {
+					newSize = requiredLength + breathingSpaceToReduceReallocations;
+				}
+				var newLargerBuffer = new byte[newSize];
 				Buffer.BlockCopy(cmdBuffer, 0, newLargerBuffer, 0, cmdBuffer.Length);
 				cmdBuffer = newLargerBuffer;
 			}


### PR DESCRIPTION
I have noticed memory fragmentation when system had been under load tests with memory profiling enabled. This patch has helped me to decrease number of objects in LOH and eventually decreased memory fragmentation.
