### PR TITLE
When we use AddRangeToSet with transaction. The method could not Set Cur...

### DIFF
--- a/src/ServiceStack.Redis/RedisClient_Set.cs
+++ b/src/ServiceStack.Redis/RedisClient_Set.cs
@@ -86,7 +86,9 @@ namespace ServiceStack.Redis
 			if (items == null)
 				throw new ArgumentNullException("items");
 			if (items.Count == 0)
-				return;
+      				throw new ArgumentEmptyException("items");
+			//	return; 
+              
 
 			if (this.Transaction != null)
 			{


### PR DESCRIPTION
...rentQueuedOperation to NULL. Then we get "The previous queued operation has not been commited error" with  another QueueCommand call.
