### PR TITLE
Fixed issue with incorrect buffer size calculation, restored ignored test

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -247,7 +247,7 @@ namespace ServiceStack.Redis
             while (bytesCopied < cmdBytes.Length)
             {
                 var copyOfBytes = BufferPool.GetBuffer();
-                var bytesToCopy = cmdBytes.Length > copyOfBytes.Length ? copyOfBytes.Length : cmdBytes.Length;
+                var bytesToCopy = Math.Min(cmdBytes.Length - bytesCopied, copyOfBytes.Length);
                 Buffer.BlockCopy(cmdBytes, bytesCopied, copyOfBytes, 0, bytesToCopy);
                 cmdBuffer.Add(new ArraySegment<byte>(copyOfBytes, 0, bytesToCopy));
                 bytesCopied += bytesToCopy;

--- a/tests/ServiceStack.Redis.Tests/Integration/RedisRegressionTestRun.cs
+++ b/tests/ServiceStack.Redis.Tests/Integration/RedisRegressionTestRun.cs
@@ -10,8 +10,7 @@ using ServiceStack.Text;
 
 namespace ServiceStack.Redis.Tests.Integration
 {
-    [Ignore("Hanging")]
-	[TestFixture, Category("Integration")]
+ 	[TestFixture, Category("Integration")]
 	public class RedisRegressionTestRun
 	{
 		private static string testData;
@@ -113,11 +112,13 @@ namespace ServiceStack.Redis.Tests.Integration
 			catch (NullReferenceException ex)
 			{
 				Debug.WriteLine("NullReferenceException StackTrace: \n" + ex.StackTrace);
-			}
+                Assert.Fail("NullReferenceException");
+            }
 			catch (Exception ex)
 			{
 				Debug.WriteLine(String.Format("\t[ERROR@{0}]: {1} => {2}",
-					host, ex.GetType().Name, ex.Message));
+					host, ex.GetType().Name, ex));
+                Assert.Fail("Exception");
 			}
 		}
 


### PR DESCRIPTION
- fixed issue with incorrect buffer size calculation
- removed ignore attribute from RedisRegressionTestRun
