### PR TITLE
Added Failing Tests For CustomType in an IList

### DIFF
--- a/tests/ServiceStack.Redis.Tests/Generic/RedisClientListTestsModels.cs
+++ b/tests/ServiceStack.Redis.Tests/Generic/RedisClientListTestsModels.cs
@@ -65,6 +65,18 @@ namespace ServiceStack.Redis.Tests.Generic
 		}
 	}
 
+    [TestFixture]
+    public class RedisClientlistTestCustomType_Failing
+        : RedisClientListTestsBase<CustomType>
+    {
+        private readonly IModelFactory<CustomType> factory = new CustomTypeFactory();
+
+        protected override IModelFactory<CustomType> Factory
+        {
+            get { return factory; }
+        }
+    }
+
 	//public class RedisClientListTestsDateTime
 	//    : RedisClientListTestsBase<DateTime>
 	//{


### PR DESCRIPTION
This produces failing tests for using a CustomType that has an
overloaded equality comparer
