### PR TITLE
Added Extension for Managed Lists

### DIFF
--- a/src/ServiceStack.Redis/Generic/ManagedListGeneric.cs
+++ b/src/ServiceStack.Redis/Generic/ManagedListGeneric.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ServiceStack.Redis.Generic
+{
+    public class ManagedList<T> : IList<T>
+    {
+        private string key = null;
+        private IRedisClientsManager manager;
+        private ManagedList() { }
+
+        public ManagedList(IRedisClientsManager manager, string key)
+        {
+            this.key = key;
+            this.manager = manager;
+        }
+
+        private IRedisClient GetClient()
+        {
+            return manager.GetClient();
+        }
+
+        private List<T> GetRedisList()
+        {
+            using (var redis = GetClient())
+            {
+                var client = redis.As<T>();
+                return client.Lists[key].ToList();
+            }
+        }
+        public int IndexOf(T item)
+        {
+            return GetRedisList().IndexOf(item);
+        }
+
+        public void Insert(int index, T item)
+        {
+            using (var redis = GetClient())
+            {
+                redis.As<T>().Lists[key].Insert(index, item);
+            }
+        }
+
+        public void RemoveAt(int index)
+        {
+            using (var redis = GetClient())
+            {
+                redis.As<T>().Lists[key].RemoveAt(index);
+            }
+        }
+
+        public T this[int index]
+        {
+            get
+            {
+                return GetRedisList()[index];
+            }
+            set
+            {
+                using (var redis = GetClient())
+                {
+                    redis.As<T>().Lists[key][index] = value;
+                }
+            }
+        }
+
+
+        public void Add(T item)
+        {
+            using (var redis = GetClient())
+            {
+                redis.As<T>().Lists[key].Add(item);
+            }
+        }
+
+        public void Clear()
+        {
+            using (var redis = GetClient())
+            {
+                redis.As<T>().Lists[key].Clear();
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            return GetRedisList().Contains(item);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            GetRedisList().CopyTo(array, arrayIndex);
+        }
+
+        public int Count
+        {
+            get { return GetRedisList().Count(); }
+        }
+
+        public bool IsReadOnly
+        {
+            get { return false; }
+        }
+
+        public bool Remove(T item)
+        {
+            var index = this.IndexOf(item);
+            if (index != -1)
+            {
+                this.RemoveAt(index);
+                return true;
+            }
+
+            return false;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return GetRedisList().GetEnumerator();
+        }
+
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable)GetRedisList()).GetEnumerator();
+        }
+    }
+}

--- a/src/ServiceStack.Redis/Generic/RedisClientsManagerExtensionsGeneric.cs
+++ b/src/ServiceStack.Redis/Generic/RedisClientsManagerExtensionsGeneric.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.Redis.Generic
+{
+    public static class RedisClientsManagerExtensionsGeneric
+    {
+        public static ManagedList<T> GetManagedList<T>(this IRedisClientsManager manager, string key)
+        {
+            return new ManagedList<T>(manager, key);
+        }
+    }
+}

--- a/src/ServiceStack.Redis/ServiceStack.Redis.csproj
+++ b/src/ServiceStack.Redis/ServiceStack.Redis.csproj
@@ -152,7 +152,9 @@
     <Compile Include="BufferPool.cs" />
     <Compile Include="Commands.cs" />
     <Compile Include="ConnectionUtils.cs" />
+    <Compile Include="Generic\ManagedListGeneric.cs" />
     <Compile Include="Generic\QueuedRedisTypedCommand.cs" />
+    <Compile Include="Generic\RedisClientsManagerExtensionsGeneric.cs" />
     <Compile Include="Generic\RedisTypedClient_App.cs" />
     <Compile Include="Generic\RedisTypedPipeline.cs" />
     <Compile Include="Generic\RedisTypedCommandQueue.cs" />

--- a/tests/ServiceStack.Redis.Tests/ManagedListGenericTests.cs
+++ b/tests/ServiceStack.Redis.Tests/ManagedListGenericTests.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ServiceStack.Redis.Generic;
+
+namespace ServiceStack.Redis.Tests
+{
+    [TestFixture]
+    public class ManagedListGenericTests
+    {
+        private IRedisClientsManager redisManager;
+
+        [SetUp]
+        public void TestSetUp()
+        {
+            if (redisManager != null) redisManager.Dispose();
+            redisManager = new BasicRedisClientManager(TestConfig.SingleHost);
+            redisManager.Exec(r => r.FlushAll());
+        }
+
+        private ManagedList<string> GetManagedList()
+        {
+            return redisManager.GetManagedList<string>("testkey");
+        }
+
+        [Test]
+        public void Can_Get_Managed_List()
+        {
+            var managedList = GetManagedList();
+
+            var testString = "simple Item to test";
+            managedList.Add(testString);
+
+            var actualList = GetManagedList();
+
+            Assert.AreEqual(managedList.First(), actualList.First());
+        }
+    }
+}

--- a/tests/ServiceStack.Redis.Tests/ServiceStack.Redis.Tests.csproj
+++ b/tests/ServiceStack.Redis.Tests/ServiceStack.Redis.Tests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Benchmarks\RedisMqHostPoolBenchmarks.cs" />
     <Compile Include="DiagnosticTests.cs" />
     <Compile Include="Generic\RedisClientListTestExtra.cs" />
+    <Compile Include="ManagedListGenericTests.cs" />
     <Compile Include="RedisExtensionTests.cs" />
     <Compile Include="RedisMqServerSpinServerTests.cs" />
     <Compile Include="RedisMqServerSleepServerTests.cs" />


### PR DESCRIPTION
This allows a user to manage redis lists as if they were a List<T>

The tests currently only cover the additional functionality of creating the managed list via the proxy, it seems unnecessary to tests all of the features as they are just wrappers of the IRedisList<T> functionality.
