### PR TITLE
System.StackOverflowException when passing null value to ServiceStack.Redis.RedisClientManagerCacheClient.Set(string, T)

### DIFF
--- a/tests/ServiceStack.Redis.Tests/RedisCacheClientTests.cs
+++ b/tests/ServiceStack.Redis.Tests/RedisCacheClientTests.cs
@@ -51,6 +51,13 @@ namespace ServiceStack.Redis.Tests
 			ModelWithIdAndName.AssertIsEqual(existingModel, model);
 		}
 
+
+		[Test]
+		public void Can_store_null_model()
+		{
+			cacheClient.Set<ModelWithIdAndName>("test-key", null);
+		}
+	    
 		[Test]
 		public void Can_Set_and_Get_key_with_all_byte_values()
 		{


### PR DESCRIPTION
https://github.com/ServiceStack/ServiceStack.Redis/issues/138
