### PR TITLE
Db and default values in Redis(Native)Client constructor

### DIFF
--- a/src/ServiceStack.Redis/RedisClient.cs
+++ b/src/ServiceStack.Redis/RedisClient.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.Redis
             Init();
         }
 
-        public RedisClient(string host, int port, string password = "", int db = DefaultDb)
+        public RedisClient(string host, int port, string password = null, int db = DefaultDb)
             : base(host, port, password, db)
         {
             Init();

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Redis
         public RedisNativeClient(string host, int port)
             : this(host, port, null) {}
 
-        public RedisNativeClient(string host, int port, string password = "", int db = DefaultDb)
+        public RedisNativeClient(string host, int port, string password = null, int db = DefaultDb)
         {
             if (host == null)
                 throw new ArgumentNullException("host");


### PR DESCRIPTION
I think it should be possible to specify which database to use in the constructor. As it is now, setting .Db is not very discoverable (IMO). I've added default values to password and db to avoid constructor explosion.

I'm also planning on adding a constructor that accepts a connection string (like `"Server=localhost;Password=foo;Db=5"` which makes it easier to configure connections through a configuration file. What do you think about that?
