### PR TITLE
Fixing Can_BlockingDequeueItemFromList Test

### DIFF
--- a/tests/ServiceStack.Redis.Tests/Generic/RedisClientListTestsBase.cs
+++ b/tests/ServiceStack.Redis.Tests/Generic/RedisClientListTestsBase.cs
@@ -102,8 +102,8 @@ namespace ServiceStack.Redis.Tests.Generic
         public void Can_BlockingDequeueItemFromList()
 		{
 			var storeMembers = Factory.CreateList();
-			storeMembers.ForEach(x => redis.AddItemToList(List, x));
-
+			storeMembers.ForEach(x => redis.EnqueueItemOnList(List, x));
+						
             var item1 = redis.BlockingDequeueItemFromList(List, new TimeSpan(0, 0, 1));
 
 			Factory.AssertIsEqual(item1, (T)storeMembers.First());


### PR DESCRIPTION
Use EnqueueItemOnList instead of AddItemToList if working with Dequeue*,
since these methods work on the list in opposite directions.
