### PR TITLE
Fixing parameter order for this call

### DIFF
--- a/src/ServiceStack.Redis/Generic/RedisTypedClient_SortedSet.cs
+++ b/src/ServiceStack.Redis/Generic/RedisTypedClient_SortedSet.cs
@@ -222,7 +222,7 @@ namespace ServiceStack.Redis.Generic
 
 		public List<T> GetRangeFromSortedSetByHighestScore(IRedisSortedSet<T> set, double fromScore, double toScore, int? skip, int? take)
 		{
-			var list = client.GetRangeFromSortedSetByHighestScore(set.Id, fromScore, toScore, take, skip);
+			var list = client.GetRangeFromSortedSetByHighestScore(set.Id, fromScore, toScore, skip, take);
 			return list.ConvertEachTo<T>();
 		}
 


### PR DESCRIPTION
The parameters were backwards in this call, which was causing no data to be returned if skip was 0.  

It looks like we don't have any tests for the generic SortedSet client, so that might be something that I can look into later.
