### PR TITLE
added missing BitCount method to RedisClient

### DIFF
--- a/src/ServiceStack.Redis/Commands.cs
+++ b/src/ServiceStack.Redis/Commands.cs
@@ -78,6 +78,7 @@ namespace ServiceStack.Redis
         public readonly static byte[] SetRange = "SETRANGE".ToUtf8Bytes();
         public readonly static byte[] GetBit = "GETBIT".ToUtf8Bytes();
         public readonly static byte[] SetBit = "SETBIT".ToUtf8Bytes();
+        public readonly static byte[] BitCount = "BITCOUNT".ToUtf8Bytes();
 
         public readonly static byte[] RPush = "RPUSH".ToUtf8Bytes();
         public readonly static byte[] LPush = "LPUSH".ToUtf8Bytes();

--- a/src/ServiceStack.Redis/Generic/RedisTypedTransaction.cs
+++ b/src/ServiceStack.Redis/Generic/RedisTypedTransaction.cs
@@ -101,7 +101,7 @@ namespace ServiceStack.Redis.Generic
                     queuedCommand.ProcessResult();
                 }
             }
-            catch (RedisTransactionFailedException e)
+            catch (RedisTransactionFailedException)
             {
                 rc = false;
             }

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -546,6 +546,14 @@ namespace ServiceStack.Redis
             return SendExpectLong(Commands.SetBit, key.ToUtf8Bytes(), offset.ToUtf8Bytes(), value.ToUtf8Bytes());
         }
 
+        public long BitCount(string key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            return SendExpectLong(Commands.BitCount, key.ToUtf8Bytes());
+        }
+
         public string RandomKey()
         {
             return SendExpectData(Commands.RandomKey).FromUtf8Bytes();

--- a/src/ServiceStack.Redis/Transaction/RedisTransaction.cs
+++ b/src/ServiceStack.Redis/Transaction/RedisTransaction.cs
@@ -100,7 +100,7 @@ namespace ServiceStack.Redis
                     queuedCommand.ProcessResult();
                 }
             }
-            catch (RedisTransactionFailedException e)
+            catch (RedisTransactionFailedException)
             {
                 rc = false;
             }

--- a/tests/ServiceStack.Redis.Tests/Generic/RedisClientTests.cs
+++ b/tests/ServiceStack.Redis.Tests/Generic/RedisClientTests.cs
@@ -116,12 +116,13 @@ namespace ServiceStack.Redis.Tests.Generic
 		}
         
         [Test]
-        public void Can_SetBit_And_GetBit()
+        public void Can_SetBit_And_GetBit_And_BitCount()
         {
             const string key = "BitKey";
             const int offset = 100;
             Redis.SetBit(key, offset, 1);
             Assert.AreEqual(1, Redis.GetBit(key,offset));
+            Assert.AreEqual(1, Redis.BitCount(key));
         }
 
 		[Test, Explicit]


### PR DESCRIPTION
Hi,

I've added the missing BitCount method because I needed it, BitOp has not been so lucky :)
