### PR TITLE
GetTypedClient is deprecated

### DIFF
--- a/tests/ServiceStack.Redis.Tests/ShippersExample.cs
+++ b/tests/ServiceStack.Redis.Tests/ShippersExample.cs
@@ -51,7 +51,7 @@ namespace ServiceStack.Redis.Tests
 			using (var redisClient = new RedisClient(TestConfig.SingleHost))
 			{
 				//Create a 'strongly-typed' API that makes all Redis Value operations to apply against Shippers
-				IRedisTypedClient<Shipper> redis = redisClient.GetTypedClient<Shipper>();
+				IRedisTypedClient<Shipper> redis = redisClient.As<Shipper>();
 
 				//Redis lists implement IList<T> while Redis sets implement ICollection<T>
 				var currentShippers = redis.Lists["urn:shippers:current"];


### PR DESCRIPTION
It would be great to change http://www.servicestack.net/docs/redis-client/redis-client as well
