### PR TITLE
made idle timeout settable

### DIFF
--- a/src/ServiceStack.Redis/PooledRedisClientManager.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.cs
@@ -39,6 +39,7 @@ namespace ServiceStack.Redis
         public int? ConnectTimeout { get; set; }
         public int? SocketSendTimeout { get; set; }
         public int? SocketReceiveTimeout { get; set; }
+        public int? IdleTimeOutSecs { get; set; }
 
         /// <summary>
         /// Gets or sets object key prefix.
@@ -233,6 +234,10 @@ namespace ServiceStack.Redis
                 {
                     inActiveClient.ReceiveTimeout = this.SocketReceiveTimeout.Value;
                 }
+                if (this.IdleTimeOutSecs.HasValue)
+                {
+                    inActiveClient.IdleTimeOutSecs = this.IdleTimeOutSecs.Value;
+                }
 
                 inActiveClient.NamespacePrefix = NamespacePrefix;
 
@@ -324,6 +329,10 @@ namespace ServiceStack.Redis
                 if (this.SocketReceiveTimeout.HasValue)
                 {
                     inActiveClient.ReceiveTimeout = this.SocketReceiveTimeout.Value;
+                }
+                if (this.IdleTimeOutSecs.HasValue)
+                {
+                    inActiveClient.IdleTimeOutSecs = this.IdleTimeOutSecs.Value;
                 }
 
                 inActiveClient.NamespacePrefix = NamespacePrefix;

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -37,6 +37,7 @@ namespace ServiceStack.Redis
         public const long DefaultDb = 0;
         public const int DefaultPort = 6379;
         public const string DefaultHost = "localhost";
+        public const int DefaultIdleTimeOutSecs = 240; //default on redis is 300
 
         internal const int Success = 1;
         internal const int OneGb = 1073741824;
@@ -60,14 +61,13 @@ namespace ServiceStack.Redis
         internal bool Active { get; set; }
         internal PooledRedisClientManager ClientManager { get; set; }
 
-        internal int IdleTimeOutSecs = 240; //default on redis is 300
         internal long LastConnectedAtTimestamp;
 
         public long Id { get; set; }
 
         public string Host { get; private set; }
         public int Port { get; private set; }
-
+        
         /// <summary>
         /// Gets or sets object key prefix.
         /// </summary>
@@ -78,6 +78,7 @@ namespace ServiceStack.Redis
         public int SendTimeout { get; set; }
 		public int ReceiveTimeout { get; set; }
         public string Password { get; set; }
+        public int IdleTimeOutSecs { get; set; }
 
         public Action<IRedisNativeClient> ConnectionFilter { get; set; }
 
@@ -127,6 +128,7 @@ namespace ServiceStack.Redis
 			ReceiveTimeout = -1;
             Password = password;
             Db = db;
+            IdleTimeOutSecs = DefaultIdleTimeOutSecs;
         }
 
         public RedisNativeClient()


### PR DESCRIPTION
I am using ServiceStack.Redis PooledRedisClientManager with redistogo.com. Redistogo closes idle client connections after 150 seconds (on the small plan). The current default idle timeout in ServiceStack.Redis is hard set at 240 seconds. This results in "No more data" exceptions when using a connection from the pool that has been closed by the server. Lowering the idle time out to < 150 (for redistogo) fixes this because RedisNativeClient.AssertConnectedSocket does the necessary checks and reconnects the client.
