### PR TITLE
Update HadExceptions if socket not connected

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -45,6 +45,7 @@ namespace ServiceStack.Redis
                 {
                     socket.Close();
                     socket = null;
+                    HadExceptions = true;
                     return;
                 }
                 Bstream = new BufferedStream(new NetworkStream(socket), 16 * 1024);


### PR DESCRIPTION
When ConnectTimeout != 0, it does not throw the exception, and
HadExceptions it is not updated. Due to that, the connection is not
disposed and the pool can not recover after a server crash

v3 commit of #184
