### PR TITLE
Fixed a problem with the implementation of the Db accessor in RedisNativeClient

### DIFF
--- a/src/ServiceStack.Redis/BasicRedisClientManager.cs
+++ b/src/ServiceStack.Redis/BasicRedisClientManager.cs
@@ -100,12 +100,6 @@ namespace ServiceStack.Redis
                 client.ConnectTimeout = this.ConnectTimeout.Value;
             }
 
-            //Set database to userSpecified if different
-            if (Db != RedisNativeClient.DefaultDb)
-            {
-                client.ChangeDb(Db);
-            }
-
             if (nextHost.RequiresAuth)
                 client.Password = nextHost.Password;
 
@@ -128,12 +122,6 @@ namespace ServiceStack.Redis
             if (this.ConnectTimeout != null)
             {
                 client.ConnectTimeout = this.ConnectTimeout.Value;
-            }
-
-            //Set database to userSpecified if different
-            if (Db != RedisNativeClient.DefaultDb)
-            {
-                client.ChangeDb(Db);
             }
 
             if (nextHost.RequiresAuth)

--- a/src/ServiceStack.Redis/PooledRedisClientManager.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.cs
@@ -241,11 +241,7 @@ namespace ServiceStack.Redis
 
                 inActiveClient.NamespacePrefix = NamespacePrefix;
 
-                //Reset database to default if changed
-                if (inActiveClient.Db != Db)
-                {
-                    inActiveClient.ChangeDb(Db);
-                }
+                inActiveClient.Db = Db;
 
                 return inActiveClient;
             }
@@ -337,11 +333,7 @@ namespace ServiceStack.Redis
 
                 inActiveClient.NamespacePrefix = NamespacePrefix;
 
-                //Reset database to default if changed
-                if (inActiveClient.Db != Db)
-                {
-                    inActiveClient.ChangeDb(Db);
-                }
+                inActiveClient.Db = Db;
 
                 return inActiveClient;
             }

--- a/src/ServiceStack.Redis/RedisClient.cs
+++ b/src/ServiceStack.Redis/RedisClient.cs
@@ -165,12 +165,6 @@ namespace ServiceStack.Redis
                 base.Set(key, bytesValue, (int)expireIn.TotalSeconds, 0, exists: false);
         }
 
-        public void ChangeDb(long db)
-        {
-            Db = db;
-            SendExpectSuccess(Commands.Select, db.ToUtf8Bytes());
-        }
-
         public List<Dictionary<string, string>> GetClientList()
         {
             var clientList = base.ClientList().FromUtf8Bytes();

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -143,10 +143,13 @@ namespace ServiceStack.Redis
             {
                 return db;
             }
-
             set
             {
-                db = value;
+                if (db != value)
+                {
+                    db = value;
+                    SendExpectSuccess (Commands.Select, db.ToUtf8Bytes ());
+                }
             }
         }
 


### PR DESCRIPTION
Fixed a problem in the RedisNativeClient implementation of IRedisNativeClient where setting the Db property fails to SELECT the desired Db if it is used after the connection to Redis has been made.
