### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The `ServiceStack.Redis.RedisClient` class below implements the following interf
 For most cases if you require access to Redis-specific functionality you would want to bind to the interface below:
 
   * [IRedisClient](https://github.com/ServiceStack/ServiceStack.Redis/wiki/IRedisClient) - Provides a friendlier, more descriptive API that lets you store values as strings (UTF8 encoding).
-  * [IRedisTypedClient](https://github.com/ServiceStack/ServiceStack.Redis/wiki/IRedisTypedClient) - created with `IRedisClient.GetTypedClient<T>()` - it returns a 'strongly-typed client' that provides a typed-interface for all redis value operations that works against any C#/.NET POCO type.
+  * [IRedisTypedClient](https://github.com/ServiceStack/ServiceStack.Redis/wiki/IRedisTypedClient) - created with `IRedisClient.As<T>()` - it returns a 'strongly-typed client' that provides a typed-interface for all redis value operations that works against any C#/.NET POCO type.
 
 The class hierachy for the C# Redis clients effectively look like:
 


### PR DESCRIPTION
IRedisClient.GetTypedClient<T>() is not available in newer versions. IRedisClient.As<T>() is used in newer versions
