### PR TITLE
Spelling error in exception message.

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -614,7 +614,7 @@ namespace ServiceStack.Redis
         {
             Log("R: {0}", r);
             if (r.Length == 0)
-                throw CreateResponseError("Zero length respose");
+                throw CreateResponseError("Zero length response");
 
             char c = r[0];
             if (c == '-')


### PR DESCRIPTION
Only because I've been staring at this error all day trying to debug some odd behavior. It should be "response", not "respose".
