### PR TITLE
Catch wrapped SocketExceptions when SslStream.Write is being used.

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -412,6 +412,15 @@ namespace ServiceStack.Redis
                 }
                 ResetSendBuffer();
             }
+            catch (IOException ex)  // several stream commands wrap SocketException in IOException
+            {
+                var socketEx = ex.InnerException as SocketException;
+                if (socketEx == null)
+                    throw;
+
+                cmdBuffer.Clear();
+                return HandleSocketException(socketEx);
+            }
             catch (SocketException ex)
             {
                 cmdBuffer.Clear();


### PR DESCRIPTION
Fixes exceptions like the following:

GeneralCacheException: An error occurred while attempting to execute a cache operation for Redis. (Error during processing of client 1: ) ---> System.IO.IOException: Unable to write data to the transport connection: An existing connection was forcibly closed by the remote host. ---> System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host.
