### PR TITLE
Update the  README removing the dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,4 +756,4 @@ type as well as serializing and de-serializing each record using Service Stack's
   - [Using the ServiceStack.Redis Client](http://michaelsarchet.com/using-the-servicestack-redis-client/) by [@msarchet](http://twitter.com/msarchet)
   - [Implementing ServiceStack.Redis.RedisClient (.NET Client for Redis)](http://www.narizwallace.com/2012/10/implementing-servicestack-redis-redisclient-net-client-for-redis/) by [@NarizWallace](https://twitter.com/NarizWallace)
   - [Getting started with Redis in ASP.NET under Windows](http://maxivak.com/getting-started-with-redis-and-asp-net-mvc-under-windows/) by [@maxivak](https://twitter.com/maxivak)
-  - [Using Redis on Windows with ServiceStack](http://www.clippersoft.net/using-redis-on-windows-with-servicestack/)
+  


### PR DESCRIPTION
The README had a dead link pointing to http://www.clippersoft.net/using-redis-on-windows-with-servicestack/ which no longer exists.