### PR TITLE
If redis password is an empty string in config file, this get's passed through to redis...

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -270,7 +270,7 @@ namespace ServiceStack.Redis
         private RedisResponseException CreateResponseError(string error)
         {
             HadExceptions = true;
-            string safeLastCommand = (Password == null) ? lastCommand : lastCommand.Replace(Password, "");
+            string safeLastCommand = (string.IsNullOrEmpty(Password)) ? lastCommand : lastCommand.Replace(Password, "");
 
             var throwEx = new RedisResponseException(
                 string.Format("{0}, sPort: {1}, LastCommand: {2}",

--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -132,7 +132,7 @@ namespace ServiceStack.Redis
 
                 Bstream = new BufferedStream(networkStream, 16 * 1024);
 
-                if (Password != null)
+                if (!string.IsNullOrEmpty(Password))
                     SendExpectSuccess(Commands.Auth, Password.ToUtf8Bytes());
 
                 if (db != 0)


### PR DESCRIPTION
...which throws the following exception:

> Client sent AUTH, but no password is set, sPort: 0, LastCommand: AUTH

Changed string null check to check against null or empty instead, which resolves this problem.