### PR TITLE
For exceptions thrown while reading the first byte from a redis reply…

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -447,7 +447,15 @@ namespace ServiceStack.Redis
 
         private int SafeReadByte()
         {
-            return Bstream.ReadByte();
+	        try
+	        {
+		        return Bstream.ReadByte();
+	        }
+	        catch (Exception)
+	        {
+		        HadExceptions = true;
+		        throw;
+	        }
         }
 
         protected void SendExpectSuccess(params byte[][] cmdWithBinaryArgs)


### PR DESCRIPTION
…, record this using the HadExceptions property.

Hi.  We encountered an error in our production environment which seemed to be triggered under heavy loads and was precipitated by a SocketException thrown during SafeReadByte.

Here's the stack trace:

System.IO.IOException: Unable to read data from the transport connection: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond. ---> System.Net.Sockets.SocketException: A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond   at System.Net.Sockets.Socket.Receive(Byte[] buffer, Int32 offset, Int32 size, SocketFlags socketFlags)   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)   --- End of inner exception stack trace ---   at System.Net.Sockets.NetworkStream.Read(Byte[] buffer, Int32 offset, Int32 size)   at System.IO.BufferedStream.ReadByte()   at ServiceStack.Redis.RedisNativeClient.SafeReadByte()   at ServiceStack.Redis.RedisNativeClient.ReadMultiData()   at ServiceStack.Redis.RedisNativeClient.SendExpectMultiData(Byte[][] cmdWithBinaryArgs)   at ServiceStack.Redis.RedisNativeClient.MGet(String[] keys)  

We found that this error would leave stale data in the RedisNativeClient's BStream which was never cleared.  So when the client is reused by a different thread executing a different MGet request, that thread gets the reply to the previous MGet.  This pattern of seeming "crosstalk" repeats indefinitely until the application pool is recycled.

I found that you already had a fix for an almost identical issue -- when a similar expection occurs during later phases of the MGet reply processing.  When this happens you mark the RedisNativeClient with the HadExceptions flag, and abort.  This causes the client state to be wiped out and the client is recreated, when next referenced by the PooledRedisClientManager.GetClient operation.

Hope I've got it right.  Please merge if you agree.

