### PR TITLE
Redis SPOP with count

### DIFF
--- a/src/ServiceStack.Redis/RedisClient_Set.cs
+++ b/src/ServiceStack.Redis/RedisClient_Set.cs
@@ -130,6 +130,11 @@ namespace ServiceStack.Redis
         {
             return SPop(setId).FromUtf8Bytes();
         }
+        
+        public List<string> PopItemsFromSet(string setId, int count)
+        {
+            return SPop(setId, count).ToStringList();
+        }
 
         public void MoveBetweenSets(string fromSetId, string toSetId, string item)
         {

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -1070,6 +1070,14 @@ namespace ServiceStack.Redis
 
             return SendExpectData(Commands.SPop, setId.ToUtf8Bytes());
         }
+        
+        public byte[][] SPop(string setId, int count)
+    	{
+    		if (setId == null)
+    			throw new ArgumentNullException("setId");
+           	
+           	return SendExpectMultiData(Commands.SPop, setId.ToUtf8Bytes(), count.ToUtf8Bytes());
+    	}
 
         public void SMove(string fromSetId, string toSetId, byte[] value)
         {


### PR DESCRIPTION
Adds support for `count` parameter to [`SPOP`](http://redis.io/commands/spop) allowing multiple items to be removed from a set at random.

    SPOP key [count]

With high level equivalent method `PopItemsFromSet`.