### PR TITLE
Fixed a bug where SET command failes for Redis prior of v2.6.12

### DIFF
--- a/src/ServiceStack.Redis/RedisClient.ICacheClient.cs
+++ b/src/ServiceStack.Redis/RedisClient.ICacheClient.cs
@@ -114,7 +114,7 @@ namespace ServiceStack.Redis
             }
             else
             {
-                Exec(r => r.Set(key, ToBytes(value), (int)expiresIn.TotalSeconds));
+                Exec(r => r.SetEx(key, (int)expiresIn.TotalSeconds, ToBytes(value)));
             }
             return true;
         }


### PR DESCRIPTION
As of version 4.0.34 the `set` command with expiry time is broken for Redis versions older than 2.6.12 (http://redis.io/commands/SET).
I have a project with Redis 2.4.6 and I decided to update it from 3.9.52 to the latest (4.0.42) only to find that the latest version doesn't work with my Redis version. Upon examining the cause, I started looking at the code and when the behavior changed. Version 4.0.33 works fine but as of c637a36e it broke.

P.S I have tested that this fix works with my project (Redis 2.4.6)