### PR TITLE
performance: create list with predefined size to avoid unnecessary GC

### DIFF
--- a/src/ServiceStack.Redis/UtilExtensions.cs
+++ b/src/ServiceStack.Redis/UtilExtensions.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Collections.Generic;
 using ServiceStack.Text;
 
 namespace ServiceStack.Redis
 {
 	internal static class UtilExtensions
 	{
-		public static List<T> ConvertEachTo<T>(this IEnumerable<string> list)
+		public static List<T> ConvertEachTo<T>(this List<string> list)
 		{
-			var to = new List<T>();
+			var to = new List<T>(list.Count);
 			foreach (var item in list)
 			{
 				to.Add(JsonSerializer.DeserializeFromString<T>(item));


### PR DESCRIPTION
I am simply creating list with predefined size just to avoid unnecessary memory copying. This happens when list's inner array size reaches current capacity and list must create a new array, twice bigger than the old, and copy all the elements to the new one.
Another, but less important thing is that List has an optimized, struct enumerator so  enumerating List with foreach is faster than via IEnumerable. The gain is going to be visible for small objects.

I have changed the method's contract (replaced IEnumerable with List) but I think it is ok since the containing class is internal and it was invoked only with Lists as parameter. If I had stayed with IEnumerable then we would have to cast to List, which would cost a little and made the code less simple and readable.