### PR TITLE
Check for EnvVar CI_REDIS for localhost tests

### DIFF
--- a/tests/ServiceStack.Redis.Tests/ConfigTests.cs
+++ b/tests/ServiceStack.Redis.Tests/ConfigTests.cs
@@ -116,7 +116,7 @@ namespace ServiceStack.Redis.Tests
         [Test]
         public void Does_set_Client_name_on_Connection()
         {
-            using (var redis = new RedisClient("localhost?Client=nunit"))
+            using (var redis = new RedisClient(TestConfig.SingleHost + "?Client=nunit"))
             {
                 var clientName = redis.GetClient();
 
@@ -127,7 +127,7 @@ namespace ServiceStack.Redis.Tests
         [Test]
         public void Does_set_Client_on_Pooled_Connection()
         {
-            using (var redisManager = new PooledRedisClientManager("localhost?Client=nunit"))
+            using (var redisManager = new PooledRedisClientManager(TestConfig.SingleHost + "?Client=nunit"))
             using (var redis = redisManager.GetClient())
             {
                 var clientName = redis.GetClient();

--- a/tests/ServiceStack.Redis.Tests/Examples/SimpleLocks.cs
+++ b/tests/ServiceStack.Redis.Tests/Examples/SimpleLocks.cs
@@ -123,7 +123,7 @@ namespace ServiceStack.Redis.Tests.Examples
                     {
                         Console.WriteLine("About to process " + clientNo);
                         //var redisClient = new RedisClient("xxxx.redis.cache.windows.net", 6379, "xxxx");
-                        var redisClient = new RedisClient("localhost", 6379);
+                        var redisClient = new RedisClient(TestConfig.SingleHost, 6379);
 
                         using (redisClient.AcquireLock("testlock1", TimeSpan.FromMinutes(3)))
                         {

--- a/tests/ServiceStack.Redis.Tests/Issues/RedisCharacterizationTests.cs
+++ b/tests/ServiceStack.Redis.Tests/Issues/RedisCharacterizationTests.cs
@@ -43,8 +43,8 @@ namespace ServiceStack.Redis.Tests.Issues
 
         private void TestForDatabaseOnConnectionString(Func<string, IRedisClientsManager> factory)
         {
-            _db1ClientManager = factory("localhost?db=1");
-            _db2ClientManager = factory("localhost?db=2");
+            _db1ClientManager = factory(TestConfig.SingleHost + "?db=1");
+            _db2ClientManager = factory(TestConfig.SingleHost + "?db=2");
 
             using (var cacheClient = _db1ClientManager.GetCacheClient())
             {
@@ -59,8 +59,8 @@ namespace ServiceStack.Redis.Tests.Issues
         [Test]
         public void WhenUsingAnInitialDatabase_CorrectDatabaseIsUsed()
         {
-            _db1ClientManager = new BasicRedisClientManager(1, "localhost");
-            _db2ClientManager = new BasicRedisClientManager(2, "localhost");
+            _db1ClientManager = new BasicRedisClientManager(1, TestConfig.SingleHost);
+            _db2ClientManager = new BasicRedisClientManager(2, TestConfig.SingleHost);
 
             using (var cacheClient = _db1ClientManager.GetCacheClient())
             {

--- a/tests/ServiceStack.Redis.Tests/TestConfig.cs
+++ b/tests/ServiceStack.Redis.Tests/TestConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using ServiceStack.Logging;
 using ServiceStack.Support;
 
@@ -12,7 +13,10 @@ namespace ServiceStack.Redis.Tests
 
 		public const bool IgnoreLongTests = true;
 
-        public const string SingleHost = "localhost";
+	    public static string SingleHost
+	    {
+	        get { return Environment.GetEnvironmentVariable("CI_REDIS") ?? "localhost"; }
+	    }
         public static readonly string[] MasterHosts = new[] { "localhost" };
         public static readonly string[] SlaveHosts = new[] { "localhost" };
 


### PR DESCRIPTION
Just Updating some of the tests to make it easier to change Redis instance location. Only done SingleHost initially, could you have a quick eye over it? Fallback to same localhost behaviour when EnvVar not present.