### PR TITLE
Make it support byte array

### DIFF
--- a/src/ServiceStack.Redis/RedisClient.KeyByteArray.cs
+++ b/src/ServiceStack.Redis/RedisClient.KeyByteArray.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.Redis
+{
+    partial class RedisClient
+    {
+        public bool Set(byte[] key, byte[] value, TimeSpan expiresIn)
+        {
+            if (AssertServerVersionNumber() >= 2600)
+            {
+                Exec(r => r.Set(key, value, 0, expiryMs: (long)expiresIn.TotalMilliseconds));
+            }
+            else
+            {
+                Exec(r => r.SetEx(key, (int)expiresIn.TotalSeconds, value));
+            }
+
+            return true;
+        }
+
+        public bool Remove(byte[] key)
+        {
+            return Del(key) == Success;
+        }
+
+
+        public bool ExpireEntryIn(byte[] key, TimeSpan expireIn)
+        {
+            if (AssertServerVersionNumber() >= 2600)
+            {
+                if (expireIn.Milliseconds > 0)
+                {
+                    return PExpire(key, (long)expireIn.TotalMilliseconds);
+                }
+            }
+
+            return Expire(key, (int)expireIn.TotalSeconds);
+        }
+    }
+}

--- a/src/ServiceStack.Redis/RedisNativeClient.KeyByteArray.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.KeyByteArray.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ServiceStack.Redis
+{
+    partial class RedisNativeClient
+    {
+        public void Set(byte[] key, byte[] value, int expirySeconds, long expiryMs = 0)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            value = value ?? new byte[0];
+
+            if (value.Length > OneGb)
+                throw new ArgumentException("value exceeds 1G", "value");
+
+            if (expirySeconds > 0)
+                SendExpectSuccess(Commands.Set, key, value, Commands.Ex, expirySeconds.ToUtf8Bytes());
+            else if (expiryMs > 0)
+                SendExpectSuccess(Commands.Set, key, value, Commands.Px, expiryMs.ToUtf8Bytes());
+            else
+                SendExpectSuccess(Commands.Set, key, value);
+        }
+
+        public void SetEx(byte[] key, int expireInSeconds, byte[] value)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+            value = value ?? new byte[0];
+
+            if (value.Length > OneGb)
+                throw new ArgumentException("value exceeds 1G", "value");
+
+            SendExpectSuccess(Commands.SetEx, key, expireInSeconds.ToUtf8Bytes(), value);
+        }
+
+        public byte[] Get(byte[] key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            return SendExpectData(Commands.Get, key);
+        }
+
+        public long HSet(byte[] hashId, byte[] key, byte[] value)
+        {
+            AssertHashIdAndKey(hashId, key);
+
+            return SendExpectLong(Commands.HSet, hashId, key, value);
+        }
+
+        public byte[] HGet(byte[] hashId, byte[] key)
+        {
+            AssertHashIdAndKey(hashId, key);
+
+            return SendExpectData(Commands.HGet, hashId, key);
+        }
+
+        public long Del(byte[] key)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            return SendExpectLong(Commands.Del, key);
+        }
+
+        public long HDel(byte[] hashId, byte[] key)
+        {
+            AssertHashIdAndKey(hashId, key);
+
+            return SendExpectLong(Commands.HDel, hashId, key);
+        }
+
+
+
+        public bool PExpire(byte[] key, long ttlMs)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            return SendExpectLong(Commands.PExpire, key, ttlMs.ToUtf8Bytes()) == Success;
+        }
+
+        public bool Expire(byte[] key, int seconds)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            return SendExpectLong(Commands.Expire, key, seconds.ToUtf8Bytes()) == Success;
+        }
+
+
+        private static void AssertHashIdAndKey(byte[] hashId, byte[] key)
+        {
+            if (hashId == null)
+                throw new ArgumentNullException("hashId");
+            if (key == null)
+                throw new ArgumentNullException("key");
+        }
+    }
+}

--- a/src/ServiceStack.Redis/ServiceStack.Redis.csproj
+++ b/src/ServiceStack.Redis/ServiceStack.Redis.csproj
@@ -148,6 +148,8 @@
     <Compile Include="BasicRedisClientManager.cs" />
     <Compile Include="BasicRedisClientManager.ICacheClient.cs" />
     <Compile Include="BasicRedisResolver.cs" />
+    <Compile Include="RedisClient.KeyByteArray.cs" />
+    <Compile Include="RedisNativeClient.KeyByteArray.cs" />
     <Compile Include="RedisResolver.cs" />
     <Compile Include="BufferPool.cs" />
     <Compile Include="Commands.cs" />


### PR DESCRIPTION
This is to add support for byte arrays. 
I wanted to contribute this to the master, so for the future releases of ServiceStack.Redis we can have byte arrays functionality in the original nuget package.