### PR TITLE
Fix not updating INFO after RedisClient is disposed

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -246,19 +246,16 @@ namespace ServiceStack.Redis
         {
             get
             {
-                if (this.info == null)
+                var lines = SendExpectString(Commands.Info);
+                this.info = new Dictionary<string, string>();
+
+                foreach (var line in lines
+                    .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
                 {
-                    var lines = SendExpectString(Commands.Info);
-                    this.info = new Dictionary<string, string>();
+                    var p = line.IndexOf(':');
+                    if (p == -1) continue;
 
-                    foreach (var line in lines
-                        .Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries))
-                    {
-                        var p = line.IndexOf(':');
-                        if (p == -1) continue;
-
-                        this.info.Add(line.Substring(0, p), line.Substring(p + 1));
-                    }
+                    this.info.Add(line.Substring(0, p), line.Substring(p + 1));
                 }
                 return this.info;
             }


### PR DESCRIPTION
`RedisClient` caches INFO results on the first call and does not update it on consequent access to `Info` property. Because PooledClientManager does not finalize `RedisClients` on calling `Dispose` the INFO command returns always the same result for old clients in the pool and contains new data for new clients. This commit removes caching and accessing `Info` property always returns fresh data from Redis.

Possible some values from INFO like `redis_version` should be cached. 