### PR TITLE
Exception in pipeline callback breaks RedisClient

### DIFF
--- a/tests/ServiceStack.Redis.Tests/Issues/PipelineIssueTests.cs
+++ b/tests/ServiceStack.Redis.Tests/Issues/PipelineIssueTests.cs
@@ -1,0 +1,43 @@
+using System;
+using NUnit.Framework;
+
+namespace ServiceStack.Redis.Tests.Issues
+{
+    [TestFixture]
+    public class PipelineIssueTests
+        : RedisClientTestsBase
+    {
+        [Test]
+        public void Disposing_Client_Clears_Pipeline()
+        {
+            var clientMgr = new PooledRedisClientManager(TestConfig.SingleHost);
+
+            using (var client = clientMgr.GetClient())
+            {
+                client.Set("k1", "v1");
+                client.Set("k2", "v2");
+                client.Set("k3", "v3");
+                
+                using (var pipe = client.CreatePipeline())
+                {
+                    pipe.QueueCommand(c => c.Get<string>("k1"), p => { throw new Exception(); });
+                    pipe.QueueCommand(c => c.Get<string>("k2"));
+
+                    try
+                    {
+                        pipe.Flush();
+                    }
+                    catch (Exception)
+                    {
+                        //The exception is expected. Swallow it.
+                    }
+                }
+            }
+
+            using (var client = clientMgr.GetClient())
+            {
+                Assert.AreEqual("v3", client.Get<string>("k3"));
+            }
+        }
+    }
+}

--- a/tests/ServiceStack.Redis.Tests/ServiceStack.Redis.Tests.csproj
+++ b/tests/ServiceStack.Redis.Tests/ServiceStack.Redis.Tests.csproj
@@ -195,6 +195,7 @@
     <Compile Include="ConfigTests.cs" />
     <Compile Include="CustomCommandTests.cs" />
     <Compile Include="Issues\AuthIssue.cs" />
+    <Compile Include="Issues\PipelineIssueTests.cs" />
     <Compile Include="LuaCachedScripts.cs" />
     <Compile Include="Examples\TestData.cs" />
     <Compile Include="Issues\RedisCharacterizationTests.cs" />


### PR DESCRIPTION
The code in the PipelineIssueTests class demonstrates the issue. Note that this issue only occurs when a PooledRedisClientManager is used.

Calling RedisAllPurposePipeline.Flush, sends all queued commands to the server. When the success-callback of one of the queued commands throws an exception, IRedisClientsManager.DisposeClient is called. This method doesn't close the socket/streams of the RedisClient. 

All queued commands have already been sent to the server, so the next response that will be read from the NetworkStream can be the response of one of the queued commands (unless the exception was thrown in the last queued command).

This means that the first command executed after the exception occurred, can receive an invalid response (the response of the next queued command). Since the underlying socket is kept open by the connectionpool, disposing the RedisClient doesn't fix it.

The fix included in this PR explicitly closes the connection by calling RedisClient.DisposeConnection when one of the callbacks throws an exception.