### PR TITLE
Fixes issue with GeoRadius when server culture is different from EN-US

### DIFF
--- a/src/ServiceStack.Redis/RedisDataExtensions.cs
+++ b/src/ServiceStack.Redis/RedisDataExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 
 namespace ServiceStack.Redis
 {
@@ -19,28 +20,28 @@ namespace ServiceStack.Redis
             return to;
         }
 
-        public static string GetResult(this RedisText from)
-        {
-            return from.Text;
-        }
+        public static double ToDouble(this RedisData data)
+            => double.Parse(data.Data.FromUtf8Bytes(),
+                            NumberStyles.Float,
+                            CultureInfo.InvariantCulture);
 
-        public static T GetResult<T>(this RedisText from)
-        {
-            return from.Text.FromJson<T>();
-        }
+        public static long ToInt64(this RedisData data)
+            => long.Parse(data.Data.FromUtf8Bytes(),
+                          NumberStyles.Integer,
+                          CultureInfo.InvariantCulture);
+
+        public static string GetResult(this RedisText from) => from.Text;
+
+        public static T GetResult<T>(this RedisText from) => from.Text.FromJson<T>();
 
         public static List<string> GetResults(this RedisText from)
-        {
-            return from.Children == null
-                ? new List<string>()
-                : from.Children.ConvertAll(x => x.Text);
-        }
+            => from.Children == null
+               ? new List<string>()
+               : from.Children.ConvertAll(x => x.Text);
 
         public static List<T> GetResults<T>(this RedisText from)
-        {
-            return from.Children == null
-                ? new List<T>()
-                : from.Children.ConvertAll(x => x.Text.FromJson<T>());
-        }
+            => from.Children == null
+               ? new List<T>()
+               : from.Children.ConvertAll(x => x.Text.FromJson<T>());
     }
 }

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -27,7 +27,7 @@ namespace ServiceStack.Redis
     /// <summary>
     /// This class contains all the common operations for the RedisClient.
     /// The client contains a 1:1 mapping of c# methods to redis operations of the same name.
-    /// 
+    ///
     /// Not threadsafe use a pooled manager
     /// </summary>
     public partial class RedisNativeClient
@@ -105,7 +105,7 @@ namespace ServiceStack.Redis
         private TimeSpan retryTimeout;
         public int RetryTimeout
         {
-            get { return (int) retryTimeout.TotalMilliseconds; }
+            get { return (int)retryTimeout.TotalMilliseconds; }
             set { retryTimeout = TimeSpan.FromMilliseconds(value); }
         }
         public int RetryCount { get; set; }
@@ -897,9 +897,9 @@ namespace ServiceStack.Redis
         public long ClientKill(string addr = null, string id = null, string type = null, string skipMe = null)
         {
             var cmdWithArgs = new List<byte[]>
-           	{
-           		Commands.Client, Commands.Kill,
-           	};
+               {
+                   Commands.Client, Commands.Kill,
+               };
 
             if (addr != null)
             {
@@ -1258,9 +1258,9 @@ namespace ServiceStack.Redis
         public byte[][] Sort(string listOrSetId, SortOptions sortOptions)
         {
             var cmdWithArgs = new List<byte[]>
-           	{
-           		Commands.Sort, listOrSetId.ToUtf8Bytes()
-           	};
+               {
+                   Commands.Sort, listOrSetId.ToUtf8Bytes()
+               };
 
             if (sortOptions.SortPattern != null)
             {
@@ -1702,9 +1702,9 @@ namespace ServiceStack.Redis
                 throw new ArgumentNullException("setId");
 
             var cmdWithArgs = new List<byte[]>
-           	{
-           		commandBytes, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
-           	};
+               {
+                   commandBytes, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
+               };
 
             if (withScores)
             {
@@ -1741,9 +1741,9 @@ namespace ServiceStack.Redis
                 throw new ArgumentNullException("setId");
 
             var cmdWithArgs = new List<byte[]>
-           	{
-           		commandBytes, setId.ToUtf8Bytes(), min.ToFastUtf8Bytes(), max.ToFastUtf8Bytes()
-           	};
+               {
+                   commandBytes, setId.ToUtf8Bytes(), min.ToFastUtf8Bytes(), max.ToFastUtf8Bytes()
+               };
 
             if (skip.HasValue || take.HasValue)
             {
@@ -1767,9 +1767,9 @@ namespace ServiceStack.Redis
                 throw new ArgumentNullException("setId");
 
             var cmdWithArgs = new List<byte[]>
-           	{
-           		commandBytes, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
-           	};
+               {
+                   commandBytes, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
+               };
 
             if (skip.HasValue || take.HasValue)
             {
@@ -1937,9 +1937,9 @@ namespace ServiceStack.Redis
                 throw new ArgumentNullException("setId");
 
             var cmdWithArgs = new List<byte[]>
-           	{
-           		Commands.ZRangeByLex, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
-           	};
+               {
+                   Commands.ZRangeByLex, setId.ToUtf8Bytes(), min.ToUtf8Bytes(), max.ToUtf8Bytes()
+               };
 
             if (skip.HasValue || take.HasValue)
             {
@@ -2241,8 +2241,12 @@ namespace ServiceStack.Redis
 
                 to.Add(new RedisGeo
                 {
-                    Longitude = double.Parse(entry.Children[0].Data.FromUtf8Bytes()),
-                    Latitude = double.Parse(entry.Children[1].Data.FromUtf8Bytes()),
+                    Longitude = double.Parse(entry.Children[0].Data.FromUtf8Bytes(),
+                                             NumberStyles.Float,
+                                             CultureInfo.InvariantCulture),
+                    Latitude  = double.Parse(entry.Children[1].Data.FromUtf8Bytes(),
+                                             NumberStyles.Float,
+                                             CultureInfo.InvariantCulture),
                     Member = members[i],
                 });
             }
@@ -2304,15 +2308,23 @@ namespace ServiceStack.Redis
                     var result = new RedisGeoResult { Unit = unit, Member = child.Children[i++].Data.FromUtf8Bytes() };
 
                     if (withDist)
-                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes());
+                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes(),
+                                                       NumberStyles.Float,
+                                                       CultureInfo.InvariantCulture);
 
                     if (withHash)
-                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes());
+                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes(),
+                                                 NumberStyles.Integer,
+                                                 CultureInfo.InvariantCulture);
 
                     if (withCoords)
                     {
-                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes());
-                        result.Latitude = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes());
+                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes(),
+                                                        NumberStyles.Float,
+                                                        CultureInfo.InvariantCulture);
+                        result.Latitude  = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes(),
+                                                        NumberStyles.Float,
+                                                        CultureInfo.InvariantCulture);
                     }
 
                     to.Add(result);
@@ -2322,7 +2334,7 @@ namespace ServiceStack.Redis
             return to;
         }
 
-        public List<RedisGeoResult> GeoRadiusByMember(string key, string member, double radius, string unit, 
+        public List<RedisGeoResult> GeoRadiusByMember(string key, string member, double radius, string unit,
             bool withCoords = false, bool withDist = false, bool withHash = false, int? count = null, bool? asc = null)
         {
             if (key == null)
@@ -2375,15 +2387,23 @@ namespace ServiceStack.Redis
                     var result = new RedisGeoResult { Unit = unit, Member = child.Children[i++].Data.FromUtf8Bytes() };
 
                     if (withDist)
-                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes());
+                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes(),
+                                                       NumberStyles.Float,
+                                                       CultureInfo.InvariantCulture);
 
                     if (withHash)
-                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes());
+                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes(),
+                                                 NumberStyles.Integer,
+                                                 CultureInfo.InvariantCulture);
 
                     if (withCoords)
                     {
-                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes());
-                        result.Latitude = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes());
+                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes(),
+                                                        NumberStyles.Float,
+                                                        CultureInfo.InvariantCulture);
+                        result.Latitude  = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes(),
+                                                        NumberStyles.Float,
+                                                        CultureInfo.InvariantCulture);
                     }
 
                     to.Add(result);

--- a/src/ServiceStack.Redis/RedisNativeClient.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient.cs
@@ -2236,17 +2236,15 @@ namespace ServiceStack.Redis
                     break;
 
                 var entry = data.Children[i];
-                if (entry.Children.Count == 0)
+
+                var children = entry.Children;
+                if (children.Count == 0)
                     continue;
 
                 to.Add(new RedisGeo
                 {
-                    Longitude = double.Parse(entry.Children[0].Data.FromUtf8Bytes(),
-                                             NumberStyles.Float,
-                                             CultureInfo.InvariantCulture),
-                    Latitude  = double.Parse(entry.Children[1].Data.FromUtf8Bytes(),
-                                             NumberStyles.Float,
-                                             CultureInfo.InvariantCulture),
+                    Longitude = children[0].ToDouble(),
+                    Latitude  = children[1].ToDouble(),
                     Member = members[i],
                 });
             }
@@ -2307,24 +2305,15 @@ namespace ServiceStack.Redis
                     var i = 0;
                     var result = new RedisGeoResult { Unit = unit, Member = child.Children[i++].Data.FromUtf8Bytes() };
 
-                    if (withDist)
-                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes(),
-                                                       NumberStyles.Float,
-                                                       CultureInfo.InvariantCulture);
+                    if (withDist) result.Distance = child.Children[i++].ToDouble();
 
-                    if (withHash)
-                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes(),
-                                                 NumberStyles.Integer,
-                                                 CultureInfo.InvariantCulture);
+                    if (withHash) result.Hash = child.Children[i++].ToInt64();
 
                     if (withCoords)
                     {
-                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes(),
-                                                        NumberStyles.Float,
-                                                        CultureInfo.InvariantCulture);
-                        result.Latitude  = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes(),
-                                                        NumberStyles.Float,
-                                                        CultureInfo.InvariantCulture);
+                        var children = child.Children[i].Children;
+                        result.Longitude = children[0].ToDouble();
+                        result.Latitude  = children[1].ToDouble();
                     }
 
                     to.Add(result);
@@ -2386,24 +2375,15 @@ namespace ServiceStack.Redis
                     var i = 0;
                     var result = new RedisGeoResult { Unit = unit, Member = child.Children[i++].Data.FromUtf8Bytes() };
 
-                    if (withDist)
-                        result.Distance = double.Parse(child.Children[i++].Data.FromUtf8Bytes(),
-                                                       NumberStyles.Float,
-                                                       CultureInfo.InvariantCulture);
+                    if (withDist) result.Distance = child.Children[i++].ToDouble();
 
-                    if (withHash)
-                        result.Hash = long.Parse(child.Children[i++].Data.FromUtf8Bytes(),
-                                                 NumberStyles.Integer,
-                                                 CultureInfo.InvariantCulture);
+                    if (withHash) result.Hash = child.Children[i++].ToInt64();
 
                     if (withCoords)
                     {
-                        result.Longitude = double.Parse(child.Children[i].Children[0].Data.FromUtf8Bytes(),
-                                                        NumberStyles.Float,
-                                                        CultureInfo.InvariantCulture);
-                        result.Latitude  = double.Parse(child.Children[i].Children[1].Data.FromUtf8Bytes(),
-                                                        NumberStyles.Float,
-                                                        CultureInfo.InvariantCulture);
+                        var children = child.Children[i].Children;
+                        result.Longitude = children[0].ToDouble();
+                        result.Latitude  = children[1].ToDouble();
                     }
 
                     to.Add(result);

--- a/src/ServiceStack.Redis/ScanResult.cs
+++ b/src/ServiceStack.Redis/ScanResult.cs
@@ -16,9 +16,7 @@ namespace ServiceStack.Redis
             for (var i = 0; i < result.Results.Count; i += 2)
             {
                 var key = result.Results[i];
-                var score = double.Parse(result.Results[i + 1].FromUtf8Bytes(),
-                                         NumberStyles.Float,
-                                         CultureInfo.InvariantCulture);
+                var score = result.Results[i + 1].ToDouble();
                 to[key.FromUtf8Bytes()] = score;
             }
             return to;

--- a/src/ServiceStack.Redis/ScanResult.cs
+++ b/src/ServiceStack.Redis/ScanResult.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Globalization;
 
 namespace ServiceStack.Redis
 {
@@ -15,7 +16,9 @@ namespace ServiceStack.Redis
             for (var i = 0; i < result.Results.Count; i += 2)
             {
                 var key = result.Results[i];
-                var score = double.Parse(result.Results[i + 1].FromUtf8Bytes());
+                var score = double.Parse(result.Results[i + 1].FromUtf8Bytes(),
+                                         NumberStyles.Float,
+                                         CultureInfo.InvariantCulture);
                 to[key.FromUtf8Bytes()] = score;
             }
             return to;


### PR DESCRIPTION
Numbers has being passed into Redis converted with InvariantCulture but parsed back without.
This pull request fixes this.
Moreover it adds extension methods for `RedisData` to eliminate duplicated logic.

Please publish updated package to NuGet after merge.