### PR TITLE
Proper casting to interface instead of unextendable redisClient.

### DIFF
--- a/src/ServiceStack.Redis/RedisClientManagerCacheClient.cs
+++ b/src/ServiceStack.Redis/RedisClientManagerCacheClient.cs
@@ -181,7 +181,7 @@ namespace ServiceStack.Redis
         {
             using (var client = GetClient())
             {
-                var redisClient = client as RedisClient;
+                var redisClient = client as IRemoveByPattern;
                 if (redisClient != null)
                 {
                     List<string> keys = redisClient.Keys(pattern).ToStringList();
@@ -200,7 +200,7 @@ namespace ServiceStack.Redis
         {
             using (var client = GetClient())
             {
-                var redisClient = client as RedisClient;
+                var redisClient = client as ICacheClientExtended;
                 if (redisClient != null)
                 {
                     return redisClient.GetTimeToLive(key);
@@ -211,7 +211,7 @@ namespace ServiceStack.Redis
 
         public IEnumerable<string> GetKeysByPattern(string pattern)
         {
-            using (var client = (RedisClient)GetClient())
+            using (var client = (ICacheClientExtended)GetClient())
             {
                 return client.GetKeysByPattern(pattern).ToList();
             }


### PR DESCRIPTION
We have a problem extending the RedisClient (we are making a prefixed redis client) because the methods are not virtual

we subclassed it anyways and just overwrote the interface methods. but the problem is that RedisClientManagerCacheClient.cs hard casted it to RedisClient instead of the appropriate interface leaving us with not possibility to overwrite this method. I fixed the usages in this PR.

Could you please merge and create a new Core release of servicestack soon?