### PR TITLE
Apply IRedisClientCacheManager interface

### DIFF
--- a/src/ServiceStack.Redis/RedisLock.cs
+++ b/src/ServiceStack.Redis/RedisLock.cs
@@ -7,10 +7,10 @@ namespace ServiceStack.Redis
 	public class RedisLock 
 		: IDisposable
 	{
-		private readonly RedisClient redisClient;
+		private readonly IRedisClient redisClient;
 		private readonly string key;
 
-		public RedisLock(RedisClient redisClient, string key, TimeSpan? timeOut)
+		public RedisLock(IRedisClient redisClient, string key, TimeSpan? timeOut)
 		{
 			this.redisClient = redisClient;
 			this.key = key;

--- a/src/ServiceStack.Redis/RedisManagerPool.cs
+++ b/src/ServiceStack.Redis/RedisManagerPool.cs
@@ -26,7 +26,7 @@ namespace ServiceStack.Redis
     /// Provides thread-safe pooling of redis client connections.
     /// </summary>
     public partial class RedisManagerPool
-        : IRedisClientsManager, IRedisFailover, IHandleClientDispose
+        : IRedisClientsManager, IRedisFailover, IHandleClientDispose, IRedisClientCacheManager
     {
         private static readonly ILog Log = LogManager.GetLogger(typeof(RedisManagerPool));
 


### PR DESCRIPTION
When replacing PooledRedisClientManager with RedisManagerPool on a project, I noticed the class was missing the interface despite being fully implemented. 