### PR TITLE
Respect ConnectTimeout when in netstandard2

### DIFF
--- a/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
+++ b/src/ServiceStack.Redis/RedisNativeClient_Utils.cs
@@ -92,17 +92,6 @@ namespace ServiceStack.Redis
             };
             try
             {
-#if NETSTANDARD2_0
-                if (IPAddress.TryParse(Host, out var ip))
-                {
-                    socket.Connect(ip, Port);
-                }
-                else
-                {
-                    var addresses = Dns.GetHostAddressesAsync(Host).Result;
-                    socket.Connect(addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork), Port);
-                }
-#else
                 if (ConnectTimeout <= 0)
                 {
                     socket.Connect(Host, Port);
@@ -114,7 +103,6 @@ namespace ServiceStack.Redis
                         : socket.BeginConnect(Host, Port, null, null);
                     connectResult.AsyncWaitHandle.WaitOne(ConnectTimeout, true);
                 }
-#endif
 
                 if (!socket.Connected)
                 {


### PR DESCRIPTION
We were doing some testing of ServiceStack.Redis and noticed that the
connect timeout is not working and would block when running on
dotnetcore. I believe the conditional that was there was needed when we
the project was targetting netstandard1.3 but now with 2.0 that whole
conditional is not needed and now the timeout is being respected after
this change.