### PR TITLE
Fix inaccurate CurrentServerTime

### DIFF
--- a/src/ServiceStack.Redis/RedisPubSubServer.cs
+++ b/src/ServiceStack.Redis/RedisPubSubServer.cs
@@ -60,7 +60,7 @@ namespace ServiceStack.Redis
             set => Interlocked.CompareExchange(ref autoRestart, value ? YES : NO, autoRestart);
         }
 
-        public DateTime CurrentServerTime => new DateTime(serverTimeAtStart.Ticks + startedAt.ElapsedTicks, DateTimeKind.Utc);
+        public DateTime CurrentServerTime => new DateTime(serverTimeAtStart.Ticks + startedAt.Elapsed.Ticks, DateTimeKind.Utc);
 
         public long BgThreadCount => Interlocked.CompareExchange(ref bgThreadCount, 0, 0);
 


### PR DESCRIPTION
The `Stopwatch.ElapsedTicks` property is _timer_ ticks, which is not the same as the `DateTime.Ticks` according to the note in the remarks section of [the documentation](https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch.elapsedticks?view=netcore-3.1#remarks) (and my testing that led to this discovery).

Try the following simple c# sample to see the difference:
```csharp
var serverTimeAtStart = DateTime.UtcNow;
var startedAt = Stopwatch.StartNew();
Thread.Sleep(5000);
var CurrentServerTime = new DateTime(serverTimeAtStart.Ticks + startedAt.ElapsedTicks, DateTimeKind.Utc);
var CorrectServerTime = new DateTime(serverTimeAtStart.Ticks + startedAt.Elapsed.Ticks, DateTimeKind.Utc);
Debug.WriteLine($"Current: {CurrentServerTime}\r\nCorrect: {CorrectServerTime}\r\nNow: {DateTime.UtcNow}");
```