### PR TITLE
In "Redis Server builds for Windows" replace defunct MS OpenTech with Memurai deriving from it

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ Contributors need to approve the [Contributor License Agreement](https://docs.go
 ### Redis Server builds for Windows
   
   * [Redis on Windows](https://github.com/ServiceStack/redis-windows)
-  * [Memurai - Redis on Windows, derived from MS Open Tech, commercial with free developer edition](https://www.memurai.com)
+  * [Memurai - Redis on Windows, derived from MS Open Tech (now defunct); commercial with free developer edition](https://www.memurai.com)
   * [Downloads for Cygwin 32bit Redis Server Windows builds](http://code.google.com/p/servicestack/wiki/RedisWindowsDownload).
   * [Project that lets you run Redis as a Windows Service](https://github.com/rgl/redis)
   * [Another Redis as a Windows Service project, which allows you to run separate service for each Redis instance](https://github.com/kcherenkov/redis-windows-service)

--- a/README.md
+++ b/README.md
@@ -953,7 +953,7 @@ Contributors need to approve the [Contributor License Agreement](https://docs.go
 ### Redis Server builds for Windows
   
   * [Redis on Windows](https://github.com/ServiceStack/redis-windows)
-  * [MS Open Tech - Redis on Windows](https://github.com/MSOpenTech/Redis)
+  * [Memurai - Redis on Windows, derived from MS Open Tech, commercial with free developer edition](https://www.memurai.com)
   * [Downloads for Cygwin 32bit Redis Server Windows builds](http://code.google.com/p/servicestack/wiki/RedisWindowsDownload).
   * [Project that lets you run Redis as a Windows Service](https://github.com/rgl/redis)
   * [Another Redis as a Windows Service project, which allows you to run separate service for each Redis instance](https://github.com/kcherenkov/redis-windows-service)


### PR DESCRIPTION
Microsoft OpenTech Redis has been abandoned in 2016 and its successor is Memurai (see this last commit in MS OpenTech fork of Redis: [link](https://github.com/microsoftarchive/redis/commit/54e8c24657f4bab22f24356bd097706193727f4f))

Memurai is a commercial product with a free downloadable developer edition.
