### PR TITLE
Get rid of Monitor.Wait and switch to Ansyc methods when calling GetClientAsync on PooledRedisClientManager

### DIFF
--- a/src/ServiceStack.Redis/PooledRedisClientManager.Async.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.Async.cs
@@ -25,7 +25,7 @@ namespace ServiceStack.Redis
             => new RedisClientManagerCacheClient(this).AsValueTaskResult<ICacheClientAsync>();
 
         ValueTask<IRedisClientAsync> IRedisClientsManagerAsync.GetClientAsync(CancellationToken token)
-            => GetClient(true).AsValueTaskResult<IRedisClientAsync>();
+            => GetClientAsync();
 
         ValueTask<ICacheClientAsync> IRedisClientsManagerAsync.GetReadOnlyCacheClientAsync(CancellationToken token)
             => new RedisClientManagerCacheClient(this) { ReadOnly = true }.AsValueTaskResult<ICacheClientAsync>();

--- a/src/ServiceStack.Redis/PooledRedisClientManager.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.cs
@@ -216,15 +216,14 @@ namespace ServiceStack.Redis
         {
             this.Start();
         }
-        
+
         private async Task<bool> waitForWriter(int msTimeout)
         {
-           writeMonitor = new AsyncMonitor();
-           var cts = new CancellationTokenSource();
-           cts.CancelAfter(msTimeout);
-           await writeMonitor.WaitAsync(cts.Token);
-           if (cts.IsCancellationRequested) return false;
-           cts.Cancel();
+           if (writeMonitor == null)
+              writeMonitor = new AsyncMonitor();
+           var delayTask = Task.Delay(msTimeout);
+           var result = await Task.WhenAny(writeMonitor.WaitAsync(), delayTask);
+           if (result == delayTask) return false;
            return true;
         }
 

--- a/src/ServiceStack.Redis/PooledRedisClientManager.cs
+++ b/src/ServiceStack.Redis/PooledRedisClientManager.cs
@@ -240,6 +240,7 @@ namespace ServiceStack.Redis
                 var poolTimedOut = false;
                 var inactivePoolIndex = -1;
 
+                var timeoutsTests = 300;
                 do
                 {
                    RedisClient inActiveClient;
@@ -268,19 +269,27 @@ namespace ServiceStack.Redis
                       }
                    }
 
-                   // Didn't get one, so let's wait a bit for a new one.
-                   if (PoolTimeout.HasValue)
+                   timeoutsTests--;
+                   if (timeoutsTests <= 0)
                    {
-                      if (!await waitForWriter(PoolTimeout.Value))
-                      {
-                         poolTimedOut = true;
-                         break;
-                      }
+                      poolTimedOut = true;
+                      break;
                    }
-                   else
-                   {
-                      await waitForWriter(RecheckPoolAfterMs);
-                   }
+                   await Task.Delay(10);
+
+                   // // Didn't get one, so let's wait a bit for a new one.
+                   // if (PoolTimeout.HasValue)
+                   // {
+                   //    if (!await waitForWriter(PoolTimeout.Value))
+                   //    {
+                   //       poolTimedOut = true;
+                   //       break;
+                   //    }
+                   // }
+                   // else
+                   // {
+                   //    await waitForWriter(RecheckPoolAfterMs);
+                   // }
                 } while (true); // Just keep repeating until we get a
 
                 if (poolTimedOut)

--- a/src/ServiceStack.Redis/ServiceStack.Redis.Core.csproj
+++ b/src/ServiceStack.Redis/ServiceStack.Redis.Core.csproj
@@ -11,7 +11,7 @@
     <PackageTags>Redis;NoSQL;Client;Distributed;Cache;PubSub;Messaging;Transactions</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Cleary.AsyncExtensions" Version="4.9.3" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
     <PackageReference Include="ServiceStack.Common.Core" Version="$(Version)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/ServiceStack.Redis/ServiceStack.Redis.Core.csproj
+++ b/src/ServiceStack.Redis/ServiceStack.Redis.Core.csproj
@@ -11,6 +11,7 @@
     <PackageTags>Redis;NoSQL;Client;Distributed;Cache;PubSub;Messaging;Transactions</PackageTags>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Cleary.AsyncExtensions" Version="4.9.3" />
     <PackageReference Include="ServiceStack.Common.Core" Version="$(Version)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">


### PR DESCRIPTION
This is working for us, but probably isn't complete enough to use for everything. Before doing any work, want to check if you're interested. This adds a dependency on Nito.Async.

We switched from StackOverflow Redis to ServiceStack Redis driver 6 or so months ago with good results. Our app does about 2 million Redis writes per minute, and it's not hard to get in a nasty state if anything goes wrong. Moving to ServiceStack async has generally been good, but we've had some issues during high loads and pool exhaustion. In same cases, it's impossible to avoid pool exhaustion, and run unbounded connection counts can run in to other problems (like SNAT exhaustion on Azure).

After digging in to the PooledRedisClientManager code, we noticed that even the Async calls use Monitor.Wait, which ties up the thread until the wait is over. Also, there's some possible locking challenges because the wait is inside the lock.

We made some changes to the code to create a separate Async GetClient method that is fully async at pool limits and uses Async constructs instead of Monitor.Wait.