### PR TITLE
Use `SSCAN` for `DeleteAll` by default to avoid pulling large sets into memory.

### DIFF
--- a/src/ServiceStack.Redis/Generic/RedisTypedClient.Async.cs
+++ b/src/ServiceStack.Redis/Generic/RedisTypedClient.Async.cs
@@ -131,24 +131,25 @@ namespace ServiceStack.Redis.Generic
 
         async Task IEntityStoreAsync<T>.DeleteAllAsync(CancellationToken token)
         {
-            await DeleteAllAsync(0,1000, token).ConfigureAwait(false);
+            await DeleteAllAsync(0,RedisConfig.DeleteAllBatchSize, token).ConfigureAwait(false);
         }
 
         private async Task DeleteAllAsync(ulong cursor, int pageSize, CancellationToken token)
         {
-            var scanResult = await AsyncNative.SScanAsync(this.TypeIdsSetKey, cursor, pageSize, token: token).ConfigureAwait(false);
-            var lastCursor = scanResult.Cursor;
-            var ids = scanResult.Results.Select(x => Encoding.UTF8.GetString(x)).ToList();
-            var urnKeys = ids.Map(t => client.UrnKey<T>(t));
-            if (urnKeys.Count > 0)
+            var callCount = 0;
+            while (cursor != 0 || callCount == 0)
             {
-                await AsyncClient.RemoveEntryAsync(urnKeys.ToArray(), token).ConfigureAwait(false);
+                var scanResult = await AsyncNative.SScanAsync(this.TypeIdsSetKey, cursor, pageSize, token: token).ConfigureAwait(false);
+                callCount++;
+                cursor = scanResult.Cursor;
+                var ids = scanResult.Results.Select(x => Encoding.UTF8.GetString(x)).ToList();
+                var urnKeys = ids.Map(t => client.UrnKey<T>(t));
+                if (urnKeys.Count > 0)
+                {
+                    await AsyncClient.RemoveEntryAsync(urnKeys.ToArray(), token).ConfigureAwait(false);
+                }
             }
-
-            if (lastCursor != 0)
-                await DeleteAllAsync(lastCursor, pageSize, token).ConfigureAwait(false);
-            else
-                await AsyncClient.RemoveEntryAsync(new[] { this.TypeIdsSetKey }, token).ConfigureAwait(false);
+            await AsyncClient.RemoveEntryAsync(new[] { this.TypeIdsSetKey }, token).ConfigureAwait(false);
         }
 
         async ValueTask<List<T>> IRedisTypedClientAsync<T>.GetValuesAsync(List<string> keys, CancellationToken token)

--- a/src/ServiceStack.Redis/Generic/RedisTypedClient.cs
+++ b/src/ServiceStack.Redis/Generic/RedisTypedClient.cs
@@ -477,7 +477,7 @@ namespace ServiceStack.Redis.Generic
                 this.RemoveEntry(urnKeys.ToArray());
             }
             if(resultCursor != 0)
-                DeleteAll(resultCursor,1000);
+                DeleteAll(resultCursor,pageSize);
             else
                 this.RemoveEntry(this.TypeIdsSetKey);
         }

--- a/src/ServiceStack.Redis/RedisClient.cs
+++ b/src/ServiceStack.Redis/RedisClient.cs
@@ -846,7 +846,7 @@ namespace ServiceStack.Redis
                 this.RemoveEntry(urnKeys.ToArray());
             }
             if(resultCursor != 0)
-                DeleteAll<T>(resultCursor, 1000);
+                DeleteAll<T>(resultCursor, pageSize);
             else
                 this.RemoveEntry(typeIdsSetKey);
         }

--- a/src/ServiceStack.Redis/RedisClient.cs
+++ b/src/ServiceStack.Redis/RedisClient.cs
@@ -831,14 +831,24 @@ namespace ServiceStack.Redis
 
         public void DeleteAll<T>()
         {
+            DeleteAll<T>(0,1000);
+        }
+
+        private void DeleteAll<T>(ulong cursor, int pageSize)
+        {
             var typeIdsSetKey = this.GetTypeIdsSetKey<T>();
-            var ids = this.GetAllItemsFromSet(typeIdsSetKey);
-            if (ids.Count > 0)
+            var scanResult = this.SScan(typeIdsSetKey, cursor, pageSize);
+            var resultCursor = scanResult.Cursor;
+            var ids = scanResult.Results.Select(x => x.FromUtf8Bytes());
+            var urnKeys = ids.Map(t => this.UrnKey(t));
+            if (urnKeys.Count > 0)
             {
-                var urnKeys = ids.ToList().ConvertAll(UrnKey<T>);
                 this.RemoveEntry(urnKeys.ToArray());
-                this.Remove(typeIdsSetKey);
             }
+            if(resultCursor != 0)
+                DeleteAll<T>(resultCursor, 1000);
+            else
+                this.RemoveEntry(typeIdsSetKey);
         }
 
         public RedisClient CloneClient()

--- a/src/ServiceStack.Redis/RedisConfig.cs
+++ b/src/ServiceStack.Redis/RedisConfig.cs
@@ -73,6 +73,11 @@ namespace ServiceStack.Redis
         public static int BufferPoolMaxSize = 500000;
 
         /// <summary>
+        /// The DeleteAll Batch Size is the number of keys returned each SSCAN when using DeleteAll on the RedisTypedClient.
+        /// </summary>
+        public static int DeleteAllBatchSize = 1000;
+
+        /// <summary>
         /// Whether Connections to Master hosts should be verified they're still master instances (default true)
         /// </summary>
         public static bool VerifyMasterConnections = true;


### PR DESCRIPTION
This is just a possible solution, ideally the client can control `pageSize` since it will impact how chatty the command is for perform the delete all, but currently this isn't a configurable option on the client that I can see.

The other trade off will be compatibility as this would require Redis 2.8 at a minimum, where as SMEMBERS has been around since 1.0. Saying that Redis latest stable is 6.2 and only officially supports -2 from stable.